### PR TITLE
If debug is enabled, ask_for_optional is a required field

### DIFF
--- a/flask_openid.py
+++ b/flask_openid.py
@@ -515,9 +515,10 @@ class OpenID(object):
             for key in ask_for:
                 if key not in ALL_KEYS:
                     raise ValueError('invalid key %r' % key)
-            for key in ask_for_optional:
-                if key not in ALL_KEYS:
-                    raise ValueError('invalid optional key %r' % key)
+            if ask_for_optional:
+                for key in ask_for_optional:
+                    if key not in ALL_KEYS:
+                        raise ValueError('invalid optional key %r' % key)
         try:
             consumer = Consumer(SessionWrapper(self), self.store_factory())
             auth_request = consumer.begin(identity_url)


### PR DESCRIPTION
I was going though [this](http://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-v-user-logins) and noticed that when `__debug__` is true I had to include `ask_for_optional` in the `try_login` function else it would break. Just included an `if ask_for_optional:` to fix this.
