### PR TITLE
add more python3 compatibility

### DIFF
--- a/flask_openid.py
+++ b/flask_openid.py
@@ -27,6 +27,14 @@ from openid.extensions.sreg import SRegRequest, SRegResponse
 from openid.consumer.consumer import Consumer, SUCCESS, CANCEL
 from openid.consumer import discover
 
+# more python3 compatibility
+import sys
+if (sys.version_info > (3, 0)):
+    str = str
+    unicode = str
+    bytes = bytes
+    basestring = (str,bytes)
+
 # python-openid is a really stupid library in that regard, we have
 # to disable logging by monkey patching.  We still call the original
 # implementation if we are in debug mode though.


### PR DESCRIPTION
class OpenID **init** use "basestring" python2 built-in function. This don't work in python3, so just add some typical replaces.
