### PR TITLE
Added base64 encoding to session data.

### DIFF
--- a/flask_openid.py
+++ b/flask_openid.py
@@ -18,6 +18,7 @@ import tempfile
 from functools import wraps
 from datetime import date
 import sys
+import base64
 
 from flask import request, session, redirect, current_app, url_for
 from werkzeug import url_quote
@@ -123,14 +124,15 @@ class SessionWrapper(object):
         rv = session[self.name_mapping.get(name, name)]
         if isinstance(rv, dict) and len(rv) == 1 and ' p' in rv:
             try:
-                return pickle.loads(rv[' p'].encode('utf-8'))
+                return pickle.loads(base64.b64decode(rv[' p'].encode('utf-8')))
             except:
                 return pickle.loads(rv[' p'])
         return rv
 
     def __setitem__(self, name, value):
         if not getattr(current_app.session_interface, 'pickle_based', True):
-            value = {' p': pickle.dumps(value, 0)}
+            b64 = base64.b64encode(pickle.dumps(value, 0))
+            value = {' p': b64.decode('utf-8')}
         session[self.name_mapping.get(name, name)] = value
 
     def __delitem__(self, name):


### PR DESCRIPTION
The session data was not JSON serializable (it was passing binary
strings). I added a call to base64.b64encode (and a matching decode) on
session keys to get around this.

I ran into this problem while using Flask with Flask-OpenID and ItsDangerous sessions. The problem seemed to be that session data being provided by Flask-OpenID contained binary strings that weren't JSON serializable, so I wrapped the __getitem__ and __setitem__ calls with base64 decoding and encoding, respectively, to have all data be passed around in UTF-8.