### PR TITLE
Use environment markers for python version dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,6 @@ if not os.path.exists("./docs/_themes/README"):
         print('You seem to be using a release. Please use the release tarball from PyPI instead of the archive from GitHub')
     sys.exit(1)
 
-extra = {}
-if sys.version_info[0] >= 3:
-    install_requires = ['Flask>=0.10.1', 'python3-openid>=2.0']
-    extra['use_2to3'] = True
-else:
-    install_requires = ['Flask>=0.3', 'python-openid>=2.0']
-
 setup(
     name='Flask-OpenID',
     version='1.2.5',
@@ -45,7 +38,16 @@ setup(
     py_modules=['flask_openid'],
     zip_safe=False,
     platforms='any',
-    install_requires=install_requires,
+    extras_require={
+        ':python_version>="3"': [
+            'Flask>=0.10.1',
+            'python3-openid>=2.0'
+        ],
+        ':python_version<"3"': [
+            'Flask>=0.3',
+            'python-openid>=2.0'
+        ]
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
@@ -56,5 +58,5 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    **extra
+    use_2to3=True
 )


### PR DESCRIPTION
- Fixes issue #54
- Use `extras_require` for compatibility with older setuptools
- Tested on python 2.7.16 and 3.7.4