### PR TITLE
Fix ModuleNotFoundError when running the example code

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -13,13 +13,12 @@
 """
 from flask import Flask, render_template, request, g, session, flash, \
      redirect, url_for, abort
-from flask.ext.openid import OpenID
-
 from openid.extensions import pape
-
 from sqlalchemy import create_engine, Column, Integer, String
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
+
+from flask_openid import OpenID
 
 # setup flask
 app = Flask(__name__)


### PR DESCRIPTION
Recent Flask versions require extensions to be imported using their own
namespace. Fixes #57.