### PR TITLE
Remove depreacted use2to3 option from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,8 @@ if not os.path.exists("./docs/_themes/README"):
         print('You seem to be using a release. Please use the release tarball from PyPI instead of the archive from GitHub')
     sys.exit(1)
 
-extra = {}
 if sys.version_info[0] >= 3:
     install_requires = ['Flask>=0.10.1', 'python3-openid>=2.0']
-    extra['use_2to3'] = True
 else:
     install_requires = ['Flask>=0.3', 'python-openid>=2.0']
 
@@ -55,6 +53,5 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
-    ],
-    **extra
+    ]
 )


### PR DESCRIPTION
Since Septembre 6th, 2021, the use of the setup option is no longer accepted and leads to failed builds. This is reported in issue #59. 

This pull request proposes to removing this option from setup.py.

I didn't see any test suite though, so I couldn't should make sure all the code is compatible with newest version of Python (which seems so).