### PR TITLE
use urllib.parse.quote instead of werkzeug.urls.url_quote

### DIFF
--- a/flask_openid.py
+++ b/flask_openid.py
@@ -20,7 +20,7 @@ from datetime import date
 import base64
 
 from flask import request, session, redirect, current_app, url_for
-from werkzeug.urls import url_quote
+from urllib.parse import quote
 
 from openid.store.filestore import FileOpenIDStore
 from openid.extensions import ax
@@ -437,7 +437,7 @@ class OpenID(object):
 
     def get_current_url(self):
         """the current URL + next."""
-        return request.base_url + '?next=' + url_quote(self.get_next_url())
+        return request.base_url + '?next=' + quote(self.get_next_url())
 
     def get_success_url(self):
         """Return the internal success URL.

--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,15 @@ import sys
 import os
 
 # This check is to make sure we checkout docs/_themes before running sdist
-if not os.path.exists("./docs/_themes/README"):
-    print('Please make sure you have docs/_themes checked out while running setup.py!')
-    if os.path.exists('.git'):
-        print('You seem to be using a git checkout, please execute the following commands to get the docs/_themes directory:')
-        print(' - git submodule init')
-        print(' - git submodule update')
-    else:
-        print('You seem to be using a release. Please use the release tarball from PyPI instead of the archive from GitHub')
-    sys.exit(1)
+# if not os.path.exists("./docs/_themes/README"):
+#     print('Please make sure you have docs/_themes checked out while running setup.py!')
+#     if os.path.exists('.git'):
+#         print('You seem to be using a git checkout, please execute the following commands to get the docs/_themes directory:')
+#         print(' - git submodule init')
+#         print(' - git submodule update')
+#     else:
+#         print('You seem to be using a release. Please use the release tarball from PyPI instead of the archive from GitHub')
+#     sys.exit(1)
 
 setup(
     name='Flask-OpenID',


### PR DESCRIPTION
### What
 - Use `urllib.parse.quote` instead of `werkzeug.urls.url_quote`
 - Remove `_themes` directory since this is not used any more. Also comment out the error logging due to this.
 
### Why
- This library does not work with latest versions `werkzeug`.
 - `werkzeug` has deprecated `url_quote` in the latest versions. Instead, this library itself uses `urllib` library's `quote` function.
 - We will be directly using this `quote` function of  `urllib` library.
